### PR TITLE
Enable StrictSlash; Use iptable for destination nating.

### DIFF
--- a/main.go
+++ b/main.go
@@ -357,6 +357,7 @@ func main() {
 	glog.Infof("Starting GCP metadataserver on port, %v", cfg.flPort)
 
 	r := mux.NewRouter()
+	r.StrictSlash(true)
 	r.Handle("/computeMetadata/v1/project/project-id", checkMetadataHeaders(http.HandlerFunc(projectIDHandler))).Methods("GET")
 	r.Handle("/computeMetadata/v1/project/numeric-project-id", checkMetadataHeaders(http.HandlerFunc(numericProjectIDHandler))).Methods("GET")
 	r.Handle("/computeMetadata/v1/project/attributes/{key}", checkMetadataHeaders(http.HandlerFunc(attributesHandler))).Methods("GET")


### PR DESCRIPTION
- gsutil relies on a 301 redirect from /computeMetadata/v1/instance/service-accounts ->
  /computeMetadata/v1/instance/service-accounts/, mux can make the same
  redirects by setting StrictSlash to true, otherise gsutil fails at the 404
  response.

- Describe iptables destination NATing as a replacement for both
  socat and ip alias, as it can do port translation as well.