### PR TITLE
close gaps to make meta data server workwith ops agent

### DIFF
--- a/server.go
+++ b/server.go
@@ -238,11 +238,14 @@ func (h *MetadataServer) checkMetadataHeaders(next http.Handler) http.Handler {
 		}
 
 		flavor := r.Header.Get("Metadata-Flavor")
+		glog.V(20).Infof("%s flavor", flavor)
+
 		if flavor == "" && r.RequestURI != "/" {
 			httpError(w, "Missing required header \"Metadata-Flavor\": \"Google\"", http.StatusForbidden, "text/html; charset=UTF-8")
 			return
 		}
-		if flavor != "Google" {
+		if flavor != "Google" && r.RequestURI != "/" {
+			glog.Infof("%s flavor", flavor)
 			h.notFound(w, r)
 			return
 		}
@@ -768,6 +771,10 @@ func (h *MetadataServer) computeMetadatav1InstanceKeyHandler(w http.ResponseWrit
 		fmt.Fprint(w, h.c.ComputeMetadata.V1.Instance.Hostname)
 	case "zone":
 		fmt.Fprint(w, h.c.ComputeMetadata.V1.Instance.Zone)
+	case "machine-type":
+		fmt.Fprint(w, h.c.ComputeMetadata.V1.Instance.MachineType)
+	case "tags":
+		fmt.Fprint(w, h.c.ComputeMetadata.V1.Instance.Tags)
 	default:
 		httpError(w, http.StatusText(http.StatusNotFound), http.StatusNotFound, "text/html; charset=UTF-8")
 		return

--- a/server.go
+++ b/server.go
@@ -772,7 +772,14 @@ func (h *MetadataServer) computeMetadatav1InstanceKeyHandler(w http.ResponseWrit
 	case "machine-type":
 		fmt.Fprint(w, h.c.ComputeMetadata.V1.Instance.MachineType)
 	case "tags":
-		fmt.Fprint(w, h.c.ComputeMetadata.V1.Instance.Tags)
+		jsonResponse, err := json.Marshal(h.c.ComputeMetadata.V1.Instance.Tags)
+		if err != nil {
+			glog.Errorf("Error converting value to JSON %v\n", err)
+			httpError(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError, "text/plain; charset=UTF-8")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonResponse)
 	default:
 		httpError(w, http.StatusText(http.StatusNotFound), http.StatusNotFound, "text/html; charset=UTF-8")
 		return


### PR DESCRIPTION
I have been looking at how to get ops agent to work with "off gcp" servers without using Blue Medora. These are the minor changes I had to do to get ops agent to work. It does require link local ip address setup as well to work. Otherwise worked perfectly.

Thought it might be of interest to you that with this minor tweak that this becomes feasible and would be of value for others as well who might have interest in this capability.  