### PR TITLE
handle maintenance-event

### DIFF
--- a/server.go
+++ b/server.go
@@ -861,6 +861,8 @@ func (h *MetadataServer) computeMetadatav1InstanceKeyHandler(w http.ResponseWrit
 		res = []byte(h.Claims.ComputeMetadata.V1.Instance.Zone)
 	case "machine-type":
 		res = []byte(h.Claims.ComputeMetadata.V1.Instance.MachineType)
+	case "maintenance-event":
+		res = []byte(h.Claims.ComputeMetadata.V1.Instance.MaintenanceEvent)
 	case "tags":
 		res, err = json.Marshal(h.Claims.ComputeMetadata.V1.Instance.Tags)
 		if err != nil {


### PR DESCRIPTION
I have added `maintenance-event` handling

Not Found in current implementation.
```
$ curl -s -H 'Metadata-Flavour: Google' http://metadata.google.internal/computeMetadata/v1/instance/maintenance-event
Not Found
```

configuration is as below:
```
$ cat /path/to/myconfig.json | jq .computeMetadata.v1.instance.maintenanceEvent
"NONE"
```

In my patch, it returns a json maintenanceEvent
```
$ curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal:8080/computeMetadata/v1/instance/maintenance-event
NONE
```

I am testing the following by launching two implementations, one current and one new

```shell
# current
$ gce_metadata_server -configFile /path/to/myconfig.json \
  -serviceAccountFile /path/to/mycredential.json \
  -interface "169.254.169.254" -port ":80" &

# my patch
$ gce_metadata_server -configFile /path/to/myconfig.json \
  -serviceAccountFile /path/to/mycredential.json \
  -interface "169.254.169.254" -port ":8080" &
```